### PR TITLE
chore: use new Pulumi and GitHub tokens managed by this repo in CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,5 +16,5 @@ jobs:
           command: up
           stack-name: holochain/github
         env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.HRA2_PULUMI_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -24,7 +24,7 @@ jobs:
           comment-on-pr: true
           diff: true
         env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.HRA2_PULUMI_ACCESS_TOKEN }}
   ci_pass:
     if: always()
     needs:


### PR DESCRIPTION
#14 introduced the GitHub and Pulumi tokens as secrets managed by Pulumi in this repo. This PR uses those new secrets in the CI workflows of this repo.

Once this PR is merged we can remove the old secrets from GitHub and delete the tokens that should no longer be used.