### PR TITLE
feat: add Nomad access token for wind-tunnel repo

### DIFF
--- a/Pulumi.github.yaml
+++ b/Pulumi.github.yaml
@@ -5,3 +5,5 @@ config:
     secure: AAABAJoOP517E0wIlRNaJM90ozYbdTffr1Nfqnz3cSnD2kAWck1akvfgFazvM5qO7LocIAM2dmyaBxbaBK9zpiNmSOpDA+4m
   holochain:hra2PulumiAccessToken:
     secure: AAABAESpY2fKLjLgiRFaQqZ1pE+H+SFfYbkKo2jKidYtZQT5KK26u3VKW/jmlG6JQTHebMt+M1OSgYk/Bt8r8UDjKbma6gbcwr/K6w==
+  wind-tunnel:nomadAccessToken:
+    secure: AAABAKN2V0c0i485JERlIbH4QUkGRlwc+jQ1VO9KYfQQdYwpC5+SJU8Pj8xwfhqpf42Fj8nUFxk8Ui6Fa1hUEB3a38Q=

--- a/main.go
+++ b/main.go
@@ -111,6 +111,10 @@ func main() {
 		if err = StandardRepositoryAccess(ctx, "wind-tunnel", windTunnel); err != nil {
 			return err
 		}
+		windTunnelConf := config.New(ctx, "wind-tunnel")
+		if err = AddNomadAccessTokenSecret(ctx, windTunnelConf, "wind-tunnel"); err != nil {
+			return err
+		}
 
 		//
 		// Holochain JS client
@@ -896,6 +900,20 @@ func AddPulumiAccessTokenSecret(ctx *pulumi.Context, cfg *config.Config, reposit
 		SecretName: pulumi.String("HRA2_PULUMI_ACCESS_TOKEN"),
 		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
 		PlaintextValue: cfg.RequireSecret("hra2PulumiAccessToken"),
+	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func AddNomadAccessTokenSecret(ctx *pulumi.Context, cfg *config.Config, repository string) error {
+	_, err := github.NewActionsSecret(ctx, fmt.Sprintf("%s-nomad-access-token", repository), &github.ActionsSecretArgs{
+		Repository: pulumi.String(repository),
+		SecretName: pulumi.String("NOMAD_ACCESS_TOKEN"),
+		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
+		PlaintextValue: cfg.RequireSecret("nomadAccessToken"),
 	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
 	if err != nil {
 		return err


### PR DESCRIPTION
Add an access token to the Wind Tunnel repo to allow submitting jobs to the Wind Tunnel Nomad cluster from the CI.