### PR TITLE
feat: add Tailscale access to wind-tunnel-runner via OAuth client

### DIFF
--- a/Pulumi.github.yaml
+++ b/Pulumi.github.yaml
@@ -5,5 +5,9 @@ config:
     secure: AAABAJoOP517E0wIlRNaJM90ozYbdTffr1Nfqnz3cSnD2kAWck1akvfgFazvM5qO7LocIAM2dmyaBxbaBK9zpiNmSOpDA+4m
   holochain:hra2PulumiAccessToken:
     secure: AAABAESpY2fKLjLgiRFaQqZ1pE+H+SFfYbkKo2jKidYtZQT5KK26u3VKW/jmlG6JQTHebMt+M1OSgYk/Bt8r8UDjKbma6gbcwr/K6w==
+  holochain:tailscaleOAuthClientId:
+    secure: AAABAMqi5wFJcWIqZxuzNJCIpvN23P92kozN1LzfTRgDN5okV6Ahw7Q9oan5qPxstw==
+  holochain:tailscaleOAuthSecret:
+    secure: AAABAIxhqX7lnm4zQfAFQzhogU0qIG/80eC9PcNPujsLal7a9mMnjvkoGpRSnanKjwCd9G4Z8KyyE56iGd6pO5+7qtzfLPd08X3UCLzAG8598YGDGTeg+TqvPLBxX1Y=
   wind-tunnel:nomadAccessToken:
     secure: AAABAJFXFB0dfeUEtmVVVdcUdA/7b2FDc7tBKhujc0paJhYN6ZSUC3S/UGft6ym7Z7Qi2dtQ8Dpl0whCatc6XL1ksLk=

--- a/main.go
+++ b/main.go
@@ -708,6 +708,9 @@ func main() {
 		if _, err = github.NewRepositoryRuleset(ctx, "wind-tunnel-runner-default", &windTunnelRunnerDefaultRepositoryRulesetArgs); err != nil {
 			return err
 		}
+		if err = AddTailscaleOAuthSecrets(ctx, conf, "wind-tunnel-runner"); err != nil {
+			return err
+		}
 
 		return nil
 	})
@@ -934,6 +937,30 @@ func AddNomadAccessTokenSecret(ctx *pulumi.Context, cfg *config.Config, reposito
 		SecretName: pulumi.String("NOMAD_ACCESS_TOKEN"),
 		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
 		PlaintextValue: cfg.RequireSecret("nomadAccessToken"),
+	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func AddTailscaleOAuthSecrets(ctx *pulumi.Context, cfg *config.Config, repository string) error {
+	_, err := github.NewActionsSecret(ctx, fmt.Sprintf("%s-tailscale-oauth-client-id", repository), &github.ActionsSecretArgs{
+		Repository: pulumi.String(repository),
+		SecretName: pulumi.String("TS_OAUTH_CLIENT_ID"),
+		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
+		PlaintextValue: cfg.RequireSecret("tailscaleOAuthClientId"),
+	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
+	if err != nil {
+		return err
+	}
+
+	_, err = github.NewActionsSecret(ctx, fmt.Sprintf("%s-tailscale-oauth-secret", repository), &github.ActionsSecretArgs{
+		Repository: pulumi.String(repository),
+		SecretName: pulumi.String("TS_OAUTH_SECRET"),
+		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
+		PlaintextValue: cfg.RequireSecret("tailscaleOAuthSecret"),
 	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
 	if err != nil {
 		return err


### PR DESCRIPTION
This gives the [wind-tunnel-runner](www.github.com/holochain/wind-tunnel-runner) CI access to the tailnet (Tailscale network) used by the Wind Tunnel runner machines so the CI can apply config changes automatically.

This token will be used as part of holochain/wind-tunnel-runner#1.