### PR TITLE
feat: add hc-static-site to pulumi using config copied from docs-pages

### DIFF
--- a/main.go
+++ b/main.go
@@ -526,22 +526,26 @@ func main() {
 		//
 		// hc-static-site
 		//
-		hcStaticSiteRepositoryArgs := StandardRepositoryArgs("hc-static-site", nil)
-		hcStaticSiteRepositoryArgs.Description = pulumi.String("Static website")
-		hcStaticSiteRepositoryArgs.AllowAutoMerge = pulumi.Bool(false)
-		hcStaticSiteRepositoryArgs.AllowRebaseMerge = pulumi.Bool(false)
-		hcStaticSiteRepositoryArgs.AllowSquashMerge = pulumi.Bool(false)
-		hcStaticSiteRepositoryArgs.AllowUpdateBranch = pulumi.Bool(false)
-		hcStaticSiteRepositoryArgs.AutoInit = pulumi.Bool(false)
-		hcStaticSiteRepositoryArgs.DeleteBranchOnMerge = pulumi.Bool(false)
-		hcStaticSiteRepositoryArgs.HasDownloads = pulumi.Bool(true)
-		hcStaticSiteRepositoryArgs.Visibility = pulumi.String("private")
-		hcStaticSiteRepositoryArgs.HomepageUrl = pulumi.String("https://www.holochain.org")
-		hcStaticSiteRepositoryArgs.MergeCommitMessage = pulumi.String("PR_TITLE")
-		hcStaticSiteRepositoryArgs.MergeCommitTitle = pulumi.String("MERGE_MESSAGE")
-		hcStaticSiteRepositoryArgs.SquashMergeCommitMessage = pulumi.String("COMMIT_MESSAGES")
-		hcStaticSiteRepositoryArgs.MergeCommitTitle = pulumi.String("COMMIT_OR_PR_TITLE")
-		hcStaticSiteRepositoryArgs.VulnerabilityAlerts = pulumi.Bool(false)
+		// There's enough different about this repo's config that it makes
+		// sense just to start from scratch.
+		hcStaticSiteRepositoryArgs := github.RepositoryArgs{
+			Name:                pulumi.String("hc-static-site"),
+			Description:         pulumi.String("Static website"),
+			Visibility:          pulumi.String("private"),
+			HasDownloads:        pulumi.Bool(true),
+			HasIssues:           pulumi.Bool(true),
+			HasProjects:         pulumi.Bool(true),
+			HasWiki:             pulumi.Bool(false),
+			VulnerabilityAlerts: pulumi.Bool(false),
+			AllowAutoMerge:      pulumi.Bool(false),
+			DeleteBranchOnMerge: pulumi.Bool(false),
+			AllowUpdateBranch:   pulumi.Bool(false),
+			AllowSquashMerge:    pulumi.Bool(false),
+			AllowRebaseMerge:    pulumi.Bool(false),
+			AllowMergeCommit:    pulumi.Bool(false),
+			AutoInit:            pulumi.Bool(false),
+			VulnerabilityAlerts: pulumi.Bool(false),
+		}
 		hcStaticSite, err := github.NewRepository(ctx, "hc-static-site", &hcStaticSiteRepositoryArgs, pulumi.Import(pulumi.ID("hc-static-site")))
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -535,7 +535,7 @@ func main() {
 		hcStaticSiteRepositoryArgs.AutoInit = pulumi.Bool(false)
 		hcStaticSiteRepositoryArgs.DeleteBranchOnMerge = pulumi.Bool(false)
 		hcStaticSiteRepositoryArgs.HasDownloads = pulumi.Bool(true)
-		hcStaticSiteRepositoryArgs.visibility = pulumi.String("private")
+		hcStaticSiteRepositoryArgs.Visibility = pulumi.String("private")
 		hcStaticSiteRepositoryArgs.HomepageUrl = pulumi.String("https://www.holochain.org")
 		hcStaticSiteRepositoryArgs.MergeCommitMessage = pulumi.String("PR_TITLE")
 		hcStaticSiteRepositoryArgs.MergeCommitTitle = pulumi.String("MERGE_MESSAGE")

--- a/main.go
+++ b/main.go
@@ -527,9 +527,21 @@ func main() {
 		// hc-static-site
 		//
 		hcStaticSiteRepositoryArgs := StandardRepositoryArgs("hc-static-site", nil)
-		hcStaticSiteRepositoryArgs.Description = pulumi.String("The hosted static site builder for the holochain.org website")
-		hcStaticSiteRepositoryArgs.HasDiscussions = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.Description = pulumi.String("Static website")
+		hcStaticSiteRepositoryArgs.AllowAutoMerge = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.AllowRebaseMerge = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.AllowSquashMerge = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.AllowUpdateBranch = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.AutoInit = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.DeleteBranchOnMerge = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.HasDownloads = pulumi.Bool(true)
+		hcStaticSiteRepositoryArgs.visibility = pulumi.String("private")
 		hcStaticSiteRepositoryArgs.HomepageUrl = pulumi.String("https://www.holochain.org")
+		hcStaticSiteRepositoryArgs.MergeCommitMessage = pulumi.String("PR_TITLE")
+		hcStaticSiteRepositoryArgs.MergeCommitTitle = pulumi.String("MERGE_MESSAGE")
+		hcStaticSiteRepositoryArgs.SquashMergeCommitMessage = pulumi.String("COMMIT_MESSAGES")
+		hcStaticSiteRepositoryArgs.MergeCommitTitle = pulumi.String("COMMIT_OR_PR_TITLE")
+		hcStaticSiteRepositoryArgs.VulnerabilityAlerts = pulumi.Bool(false)
 		hcStaticSite, err := github.NewRepository(ctx, "hc-static-site", &hcStaticSiteRepositoryArgs, pulumi.Import(pulumi.ID("hc-static-site")))
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -544,7 +544,6 @@ func main() {
 			AllowRebaseMerge:    pulumi.Bool(false),
 			AllowMergeCommit:    pulumi.Bool(false),
 			AutoInit:            pulumi.Bool(false),
-			VulnerabilityAlerts: pulumi.Bool(false),
 		}
 		hcStaticSite, err := github.NewRepository(ctx, "hc-static-site", &hcStaticSiteRepositoryArgs, pulumi.Import(pulumi.ID("hc-static-site")))
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -524,6 +524,41 @@ func main() {
 		}
 
 		//
+		// hc-static-site
+		//
+		hcStaticSiteRepositoryArgs := StandardRepositoryArgs("hc-static-site", nil)
+		hcStaticSiteRepositoryArgs.Description = pulumi.String("The hosted static site builder for the holochain.org website")
+		hcStaticSiteRepositoryArgs.HasDiscussions = pulumi.Bool(false)
+		hcStaticSiteRepositoryArgs.HomepageUrl = pulumi.String("https://www.holochain.org")
+		hcStaticSite, err := github.NewRepository(ctx, "hc-static-site", &hcStaticSiteRepositoryArgs, pulumi.Import(pulumi.ID("hc-static-site")))
+		if err != nil {
+			return err
+		}
+		if err = RequireMainAsDefaultBranch(ctx, "hc-static-site", hcStaticSite); err != nil {
+			return err
+		}
+		if err = StandardRepositoryAccess(ctx, "hc-static-site", hcStaticSite); err != nil {
+			return err
+		}
+		hcStaticSiteDefaultRepositoryRulesetArgs := DefaultRepositoryRulesetArgs(hcStaticSite, NewRulesetOptions().withExtraStatusChecks([]github.RepositoryRulesetRulesRequiredStatusChecksRequiredCheckArgs{
+			{
+				IntegrationId: pulumi.Int(13473), // Netlify
+				Context:       pulumi.String("Header rules - holochain-prod"),
+			},
+			{
+				IntegrationId: pulumi.Int(13473), // Netlify
+				Context:       pulumi.String("netlify/holochain-prod/deploy-preview"),
+			},
+			{
+				IntegrationId: pulumi.Int(13473), // Netlify
+				Context:       pulumi.String("Redirect rules - holochain-prod"),
+			},
+		}))
+		if _, err = github.NewRepositoryRuleset(ctx, "hc-static-site-default", &hcStaticSiteDefaultRepositoryRulesetArgs); err != nil {
+			return err
+		}
+
+		//
 		// scaffolding
 		//
 		scaffoldingDescription := "Scaffolding tool to quickly generate and modify holochain applications"


### PR DESCRIPTION
This gets the Holochain website under Pulumi. The main goal is to make it so we can bypass cocogitto-bot's ability to block a PR.