### PR TITLE
feat: threefold tfchain wallet mnemonic

### DIFF
--- a/Pulumi.github.yaml
+++ b/Pulumi.github.yaml
@@ -43,3 +43,5 @@ config:
     secure: AAABAPPMLayK4tU/kYAF1iznH5dfQ/1noL83G2M0T0du6kSI5z0xdYmmoGeVUpKpeYJ6UTrQ7mPG/pkuzPMWLGvv3a6Zq3J9
   holochain:claudeCodeOauthToken:
     secure: AAABAMM1RkgKDbPBHmuZdx+1ciCJTzDRSd/o2cm0QUPmo4jd1AICHf2qe/Vpcjvid+kFh3DuHiS9cZOgZKuG6G1NTi0l+7apL0jPZ7d+Nl1kdZqKLUWH/0zNPoZq9ng53Tr9LCZAxsa86/Jq5b9ijJXaiBxJ0jMEqGciMmBNTGtqwiqnlGrUmMqdEpE=
+  holochain:threefoldTfChainWalletMnemonic:
+    secure: AAABAHnzklqdwRGuZktNgbwY8fqwFMl5DM8jrN7AuFz6NXAvaJBukfoUvYFoq5YQObo6eaooQbInhK6LAw8mulpGjhzCQmUsFLLlIHrShD28k9iKaKnfpkiE/SRzzuVSoJAdKxS0tg6fdpPIMAc=

--- a/main.go
+++ b/main.go
@@ -150,6 +150,9 @@ func main() {
 		if err = AddClaudeCodeOauthTokenSecret(ctx, conf, "wind-tunnel"); err != nil {
 			return err
 		}
+		if err = AddThreefoldTfChainWalletMnemonic(ctx, conf, "wind-tunnel"); err != nil {
+			return err
+		}
 
 		//
 		// Holochain JS client
@@ -1790,6 +1793,17 @@ func AddClaudeCodeOauthTokenSecret(ctx *pulumi.Context, cfg *config.Config, repo
 		SecretName: pulumi.String("CLAUDE_CODE_OAUTH_TOKEN"),
 		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
 		PlaintextValue: cfg.RequireSecret("claudeCodeOauthToken"),
+	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
+
+	return err
+}
+
+func AddThreefoldTfChainWalletMnemonic(ctx *pulumi.Context, cfg *config.Config, repository string) error {
+	_, err := github.NewActionsSecret(ctx, fmt.Sprintf("%s-threefold-tfchain-wallet-mnemonic", repository), &github.ActionsSecretArgs{
+		Repository: pulumi.String(repository),
+		SecretName: pulumi.String("THREEFOLD_TFCHAIN_WALLET_MNEMONIC"),
+		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
+		PlaintextValue: cfg.RequireSecret("threefoldTfChainWalletMnemonic"),
 	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
 
 	return err


### PR DESCRIPTION
Add our tfchain wallet mnemonic to wind-tunnel repo, so we can deploy nodes from CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated credential configuration to support wallet-based authentication instead of previous token approach
  * Implemented automated secret initialization workflow for wallet credentials within GitHub Actions
  * Enhanced repository initialization process to include wallet credential configuration and setup
  * Improved credential management infrastructure for better security and integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->