### PR TITLE
Add contributing guidelines to repos

### DIFF
--- a/files/CONTRIBUTING.md
+++ b/files/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to {{REPO_NAME}}
+
+Thank you for your interest in contributing to {{REPO_NAME}}!
+
+## Getting Started
+
+1. Fork the repository.
+2. Create a feature branch from the default branch (usually `main`).
+3. Make your changes.
+4. Submit a pull request.
+
+## Commits
+
+The commits are used to generate the changelog upon a release, therefore keep
+them clean. To help with keeping them clean, follow these principles:
+
+- Use [conventional commits](https://www.conventionalcommits.org/) for commit
+  messages. You can also use Markdown, especially in the body.
+- Keep commits atomic, meaning that each commit should build and pass all unit
+  tests. If a new feature is added or a bug is fixed, then fix the tests in the
+  same commit.
+- In case of changes on the origin branch, always rebase, **NEVER** merge.
+- Avoid referencing the issue or PR number in the commit message, as the
+  automated changelog will add this reference for you.
+
+## Pull Requests
+
+- All changes require a pull request and at least one approving review.
+- Add a short, clear, and hand-written description of the change proposed by
+  the PR. AI tooling may add an in-depth summary below your description, so
+  keep it high-level, but ensure that you include one.
+- PRs must pass CI checks before merging.
+- Keep PRs focused — one logical change per PR.
+- Add comments to your own PR before requesting review to explain the approach
+  or to add questions for the reviewers.
+- Ensure all review threads are resolved before merging.
+- Use `fixup!` commits to address review comments and make additional changes
+  once the PR is open, as this allows the reviewers to see what has changed
+  between reviews.
+- When addressing a review comment, link to the commit that addressed the
+  comment, even if it is a `fixup!` commit that will be squashed later.
+- After an approval, rebase on the base branch. If this is done via the GitHub
+  UI, no re-approval will be needed. However, if this is done locally, then a
+  re-approval is required.
+- Squash all `fixup!` commits and clean up the commit history before merging
+  into the base branch. You can do this at the same time as rebasing with
+  `git rebase --autosquash <base_branch>`. For older versions of git, you may
+  need to use `git rebase --autosquash --interactive <base_branch>`, which will
+  perform an interactive rebase with all of the `fixup!` commits rearranged and
+  marked as fixup, you can then accept this interactive rebase.
+- We will reject PRs that are purely cosmetic and appear to have been automated
+  with tooling, such as correcting spelling and grammatical mistakes. If you
+  believe that such a change is critical in making the documentation or code
+  more readable, or if the change corrects a real logical mistake in the text,
+  then submit such a PR with a description explaining the critical correction.
+- All AI-generated PRs must have been self-reviewed. If a PR is judged to be
+  AI-generated, not checked by the author, and needs a lot of work to be
+  consistent with the existing codebase and/or it does not solve the problem it
+  claims to, then we will close the PR without comment.
+
+## Reporting Issues
+
+- Use GitHub Issues to report bugs or request features.
+- Search existing issues before creating a new one.
+- Include reproduction steps for bug reports.
+
+## Development Setup
+
+Refer to the repository's README for specific setup instructions.
+
+## Code of Conduct
+
+We are committed to providing a welcoming and inclusive experience for
+everyone. Please be respectful and constructive in all interactions.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+same license as the project.

--- a/main.go
+++ b/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"crypto/sha256"
+	_ "embed"
 	"fmt"
+	"strings"
 
 	"github.com/pulumi/pulumi-github/sdk/v6/go/github"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
+
+//go:embed files/CONTRIBUTING.md
+var contributingMdContent string
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
@@ -104,6 +110,9 @@ func main() {
 		if err = AddCachixAuthTokenSecret(ctx, conf, "holochain-wasmer"); err != nil {
 			return err
 		}
+		if err = AddContributingGuide(ctx, "holochain-wasmer", holochainWasmer); err != nil {
+			return err
+		}
 
 		//
 		// wind tunnel
@@ -154,6 +163,9 @@ func main() {
 			return err
 		}
 		if err = AddHolochainNotifierMattermostBotPersonalAccessToken(ctx, conf, "wind-tunnel"); err != nil {
+			return err
+		}
+		if err = AddContributingGuide(ctx, "wind-tunnel", windTunnel); err != nil {
 			return err
 		}
 
@@ -310,6 +322,9 @@ func main() {
 		if err = AddReleaseIntegrationSupport(ctx, conf, "sbd", sbd); err != nil {
 			return err
 		}
+		if err = AddContributingGuide(ctx, "sbd", sbd); err != nil {
+			return err
+		}
 
 		//
 		// Tx5
@@ -335,6 +350,9 @@ func main() {
 			return err
 		}
 		if err = AddReleaseIntegrationSupport(ctx, conf, "tx5", tx5); err != nil {
+			return err
+		}
+		if err = AddContributingGuide(ctx, "tx5", tx5); err != nil {
 			return err
 		}
 
@@ -364,6 +382,9 @@ func main() {
 		if err = AddReleaseIntegrationSupport(ctx, conf, "lair", lair); err != nil {
 			return err
 		}
+		if err = AddContributingGuide(ctx, "lair", lair); err != nil {
+			return err
+		}
 
 		//
 		// Holochain CHC Service
@@ -389,6 +410,9 @@ func main() {
 			return err
 		}
 		if err = AddReleaseIntegrationSupport(ctx, conf, "hc-chc-service", hcChcService); err != nil {
+			return err
+		}
+		if err = AddContributingGuide(ctx, "hc-chc-service", hcChcService); err != nil {
 			return err
 		}
 
@@ -418,6 +442,9 @@ func main() {
 		if err = AddReleaseIntegrationSupport(ctx, conf, "holochain-serialization", holochainSerialization); err != nil {
 			return err
 		}
+		if err = AddContributingGuide(ctx, "holochain-serialization", holochainSerialization); err != nil {
+			return err
+		}
 
 		//
 		// Influxive
@@ -443,6 +470,9 @@ func main() {
 			return err
 		}
 		if err = AddReleaseIntegrationSupport(ctx, conf, "influxive", influxive); err != nil {
+			return err
+		}
+		if err = AddContributingGuide(ctx, "influxive", influxive); err != nil {
 			return err
 		}
 
@@ -558,6 +588,9 @@ func main() {
 		if err = AddCachixAuthTokenSecret(ctx, conf, "kitsune2"); err != nil {
 			return err
 		}
+		if err = AddContributingGuide(ctx, "kitsune2", kitsune2); err != nil {
+			return err
+		}
 
 		//
 		// docs-pages
@@ -625,6 +658,9 @@ func main() {
 			return err
 		}
 		if err = AddHolochainBackportLabels(ctx, "scaffolding", scaffolding); err != nil {
+			return err
+		}
+		if err = AddContributingGuide(ctx, "scaffolding", scaffolding); err != nil {
 			return err
 		}
 
@@ -816,6 +852,9 @@ func main() {
 		if err = AddReleaseIntegrationSupport(ctx, conf, "hc-http-gw", hcHttpGw); err != nil {
 			return err
 		}
+		if err = AddContributingGuide(ctx, "hc-http-gw", hcHttpGw); err != nil {
+			return err
+		}
 
 		//
 		// network-services
@@ -970,6 +1009,9 @@ func main() {
 		if err = AddReleaseIntegrationSupport(ctx, conf, "rand-utf8", randUtf8); err != nil {
 			return err
 		}
+		if err = AddContributingGuide(ctx, "rand-utf8", randUtf8); err != nil {
+			return err
+		}
 
 		//
 		// serde-json
@@ -992,6 +1034,9 @@ func main() {
 			return err
 		}
 		if err = AddReleaseIntegrationSupport(ctx, conf, "serde-json", serdeJson); err != nil {
+			return err
+		}
+		if err = AddContributingGuide(ctx, "serde-json", serdeJson); err != nil {
 			return err
 		}
 
@@ -1322,6 +1367,9 @@ func main() {
 			return err
 		}
 		if err = AddReleaseIntegrationSupport(ctx, conf, "hc-auth-server", hcAuthServer); err != nil {
+			return err
+		}
+		if err = AddContributingGuide(ctx, "hc-auth-server", hcAuthServer); err != nil {
 			return err
 		}
 
@@ -1923,4 +1971,46 @@ func AddRepositoryLabels(ctx *pulumi.Context, name string, repository *github.Re
 // AddHolochainBackportLabels adds standard backport labels to a repository.
 func AddHolochainBackportLabels(ctx *pulumi.Context, name string, repository *github.Repository) error {
 	return AddRepositoryLabels(ctx, name, repository, ShouldBackport05, ShouldBackport06)
+}
+
+// AddContributingGuide adds the shared CONTRIBUTING.md file to the repository
+// via a pull request against the `main` branch if the content has changed
+// since the last deployment.
+func AddContributingGuide(ctx *pulumi.Context, name string, repository *github.Repository) error {
+	content := strings.ReplaceAll(contributingMdContent, "{{REPO_NAME}}", name)
+	contentHash := pulumi.String(fmt.Sprintf("%x", sha256.Sum256([]byte(content))))
+
+	baseBranch := pulumi.String("main")
+
+	branch, err := github.NewBranch(ctx, fmt.Sprintf("%s-contributing-md-branch", name), &github.BranchArgs{
+		Repository:   repository.Name,
+		Branch:       pulumi.String("chore/update-contributing-guide"),
+		SourceBranch: baseBranch,
+	}, pulumi.ReplacementTrigger(contentHash))
+	if err != nil {
+		return err
+	}
+
+	file, err := github.NewRepositoryFile(ctx, fmt.Sprintf("%s-contributing-md", name), &github.RepositoryFileArgs{
+		Repository:        repository.Name,
+		Branch:            branch.Branch,
+		File:              pulumi.String("CONTRIBUTING.md"),
+		Content:           pulumi.String(content),
+		CommitMessage:     pulumi.String("chore: update the CONTRIBUTING.md with shared content"),
+		CommitAuthor:      pulumi.String("Holochain Repository Automation"),
+		CommitEmail:       pulumi.String("hra@holochain.org"),
+		OverwriteOnCreate: pulumi.Bool(true),
+	}, pulumi.ReplacementTrigger(contentHash))
+	if err != nil {
+		return err
+	}
+
+	_, err = github.NewRepositoryPullRequest(ctx, fmt.Sprintf("%s-contributing-md-pr", name), &github.RepositoryPullRequestArgs{
+		BaseRepository: repository.Name,
+		BaseRef:        baseBranch,
+		HeadRef:        branch.Branch,
+		Title:          pulumi.String("chore: update the CONTRIBUTING.md with shared content"),
+		Body:           pulumi.String("This PR updates the CONTRIBUTING.md file with the content from the shared file in the hc-github-config repo."),
+	}, pulumi.DependsOn([]pulumi.Resource{file}), pulumi.ReplacementTrigger(contentHash))
+	return err
 }


### PR DESCRIPTION
Add a function to create a CONTRIBUTING.md guidelines file in the repos that use the release integration tooling and then create a PR to add the file to the default branch. The hash of the CONTRIBUTING.md content is a Pulumi resource meaning that if the content changes then a new PR should be created. There is a drawback here where I think that the branch will always be created by Pulumi even if nothing changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CONTRIBUTING.md can be automatically added and customized for repositories as part of project setup.

* **Documentation**
  * Adds a comprehensive CONTRIBUTING.md covering getting started, commit and PR guidelines, review workflow (including follow-ups and rebases), AI-generated PR self-review guidance, issue reporting, development setup, Code of Conduct, and licensing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->