### PR TITLE
fix: remove contributing guidelines resources from archived repos

### DIFF
--- a/main.go
+++ b/main.go
@@ -412,9 +412,6 @@ func main() {
 		if err = AddReleaseIntegrationSupport(ctx, conf, "hc-chc-service", hcChcService); err != nil {
 			return err
 		}
-		if err = AddContributingGuide(ctx, "hc-chc-service", hcChcService); err != nil {
-			return err
-		}
 
 		//
 		// Holochain Serialization
@@ -470,9 +467,6 @@ func main() {
 			return err
 		}
 		if err = AddReleaseIntegrationSupport(ctx, conf, "influxive", influxive); err != nil {
-			return err
-		}
-		if err = AddContributingGuide(ctx, "influxive", influxive); err != nil {
 			return err
 		}
 
@@ -1034,9 +1028,6 @@ func main() {
 			return err
 		}
 		if err = AddReleaseIntegrationSupport(ctx, conf, "serde-json", serdeJson); err != nil {
-			return err
-		}
-		if err = AddContributingGuide(ctx, "serde-json", serdeJson); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
After adding the config to add CONTRIBUTING.md to the supported repos in #75, it was found that 3 repos are not actually supported which caused the deployment to fail. This PR removes the support for those unsupported repos. The repos in question are:

1. `serde-json` - returned a `404` error, possibly the HRA2 account doesn't have access to this repo but it's not an actively-worked-on repo anyways.
2. `hc-chc-service` - returned a `404` error, this repo has been archived so we can remove support.
3. `influxive` - returned a `404` error, this repo has been archived so we can remove support.