### PR TITLE
feat: add HRA2_GITHUB_TOKEN with normal permissions to hc-spin repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -710,6 +710,9 @@ func main() {
 		if err = AddHolochainBackportLabels(ctx, "hc-spin", hcSpin); err != nil {
 			return err
 		}
+		if err = AddGithubUserTokenSecret(ctx, conf, "hc-spin"); err != nil {
+			return err
+		}
 
 		//
 		// kangaroo-electron


### PR DESCRIPTION
> [!Note]
> Pulumi preview flags that the peerkit repo's pages resource has changed.
> See: https://github.com/holochain/hc-github-config/pull/85#issuecomment-4624076815