### PR TITLE
feat: add admin PAT to the actions repo so it can modify workflows

### DIFF
--- a/Pulumi.github.yaml
+++ b/Pulumi.github.yaml
@@ -49,3 +49,5 @@ config:
     secure: AAABACRJURtkQbAnZmbb7tYn3e70n48fyccTJ3/4op0AmLxrkO4doFfP2RqjasYq6BGKRn4KxLA65MDC73PihYHh91f47hzRNXvXcPNVNTXxLuD6DP2nZwEyrcqtWjQSflW3TaiF4dsG4mD5mB96/WzS3HpbeSN+awfwOUHJl1GYGDEmhbLynbPjEnwIYVsp3KRj7oHwuZqVlQzWL+dKOA==
   holochain:holochainNotifierMattermostBotPersonalAccessToken:
     secure: AAABAD/pQfAJkM65UU5guL8PaDe7eHv+bwTJZOQAg3XKAmtaCBK7x0CGFOt1GBWQ9W1CGIxKFNGccw==
+  holochain:hra2GithubWorkflowsToken:
+    secure: AAABAMcxPgm7GQcNAg/YpoQxH20eqTl+5W/6P/jo5f6CB3SB01iai0ZNFBheuuIGr1vTn9tBedAzhlKbROlRsi1KITqk2OWg

--- a/main.go
+++ b/main.go
@@ -1289,6 +1289,9 @@ func main() {
 		if _, err = github.NewRepositoryRuleset(ctx, "actions-default", &actionsDefaultRepositoryRulesetArgs); err != nil {
 			return err
 		}
+		if err = AddGithubWorkflowsTokenSecret(ctx, conf, "actions"); err != nil {
+			return err
+		}
 
 		//
 		// Mattermost bot

--- a/main.go
+++ b/main.go
@@ -1659,6 +1659,18 @@ func AddGithubUserTokenSecret(ctx *pulumi.Context, cfg *config.Config, repositor
 	return err
 }
 
+func AddGithubWorkflowsTokenSecret(ctx *pulumi.Context, cfg *config.Config, repository string) error {
+	// A GITHUB_TOKEN with standard repository access + permissions to edit and control workflows.
+	_, err := github.NewActionsSecret(ctx, fmt.Sprintf("%s-github-token", repository), &github.ActionsSecretArgs{
+		Repository: pulumi.String(repository),
+		SecretName: pulumi.String("HRA2_GITHUB_TOKEN"),
+		// The GitHub API only accepts encrypted values. This will be encrypted by the provider before being sent.
+		PlaintextValue: cfg.RequireSecret("hra2GithubWorkflowsToken"),
+	}, pulumi.DeleteBeforeReplace(true), pulumi.IgnoreChanges([]string{"encryptedValue"}))
+
+	return err
+}
+
 func AddGithubAdminTokenSecret(ctx *pulumi.Context, cfg *config.Config, repository string) error {
 	// A GITHUB_TOKEN with more access rights to larger scopes.
 	_, err := github.NewActionsSecret(ctx, fmt.Sprintf("%s-github-token", repository), &github.ActionsSecretArgs{


### PR DESCRIPTION
The new automated release process requires modifying GitHub workflow files, which requires a PAT with the `workflow` scope.