### PR TITLE
feat(holochain-client-js): add release support

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,6 +207,9 @@ func main() {
 		if _, err = github.NewRepositoryRuleset(ctx, "holochain-client-js-release", &jsClientReleaseRepositoryRulesetArgs); err != nil {
 			return err
 		}
+		if err = AddNpmReleaseSupport(ctx, conf, "holochain-client-js", jsClient); err != nil {
+			return err
+		}
 		if err = AddHolochainBackportLabels(ctx, "holochain-client-js", jsClient); err != nil {
 			return err
 		}


### PR DESCRIPTION
## What changed

Adds release support for the Holochain JavaScript client. The repository will receive the `hra-release` label and the `HRA2_GITHUB_TOKEN` Actions secret.

## Why

The release automation needs the label to identify release pull requests and the token to perform its GitHub operations.

## Notes

Validated with `go test ./...`, Go formatting, and Git diff whitespace checks. The pull request Pulumi preview should show the new label and secret before deployment.