### PR TITLE
ci: Pass github-token to pulumi/actions for PR comments

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -23,6 +23,9 @@ jobs:
           stack-name: holochain/github
           comment-on-pr: true
           diff: true
+          # Dependabot-triggered runs get a read-only `github.token`, which this action would
+          # otherwise default to and fail to comment with. Use our own token instead.
+          github-token: ${{ secrets.HRA2_GITHUB_TOKEN }}
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.HRA2_PULUMI_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pass `github-token: ${{ secrets.HRA2_GITHUB_TOKEN }}` as an input to `pulumi/actions` in `preview.yaml`, so `comment-on-pr` uses our own token.

## Why

Every Dependabot PR fails the `preview` job, while every other branch passes. The Pulumi preview itself succeeds — it logs into Pulumi Cloud and reads all 542 resources, proving both Dependabot secrets resolve correctly. The failure is the PR comment that follows:

```
HttpError: Resource not accessible by integration
    at .../pulumi/actions/v7/webpack:/.../@octokit/request/dist-node/index.js:86
```

`pulumi/actions` builds its Octokit client from the **`github-token` input** (`config.ts` → `getInput('github-token')`), which defaults to `${{ github.token }}`. We only set `GITHUB_TOKEN` in `env:`, which feeds the Pulumi CLI's GitHub provider but is invisible to `core.getInput`. So commenting fell back to the workflow's own token — and Dependabot-triggered `pull_request` events always get a read-only one, which a `permissions:` block cannot override.

`HRA2_GITHUB_TOKEN` is a PAT and already registered as a Dependabot secret (`main.go:86`), so it is not subject to that restriction.

## Notes

- Preview comments will now be authored by `hra2` rather than `github-actions[bot]`.
- This does not retroactively fix #99 — that PR needs `@dependabot rebase` to pick up the new workflow.
- `deploy.yaml` needs no change; it does not comment on PRs.