### PR TITLE
feat: add ai policy to AddContributingGuide

### DIFF
--- a/files/AI_POLICY.md
+++ b/files/AI_POLICY.md
@@ -1,0 +1,62 @@
+# AI Policy for {{REPO_NAME}}
+
+If you plan to contribute to {{REPO_NAME}} using AI tools, you **must** read,
+understand and follow this policy.
+
+The maintainers of this project support using AI (i.e., LLMs) as tools for coding,
+however we don't want to interact directly with bots. We hold a high
+bar for all contributions to our projects. Thus, contributions must come from a human
+who understands the submitted code or text, can explain it, and is responsible for
+its quality as if they wrote it themselves. Using AI as a tool to help you write
+or reason about a contribution is fine; submitting AI output you don't understand,
+or relaying messages between a maintainer and an AI, is not.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block (e.g., using `>`) and disclosed as such. It must be
+accompanied by human commentary explaining the relevance and implications of
+the context.
+
+## Disclosure
+
+You **must** disclose any significant use of AI tools in your contributions, i.e.
+tell us if an AI tool generated or substantially shaped the content
+you submit — code, prose or commit messages — including agents, chat assistants
+and AI-assisted editors. Mechanical editor autocompletion of a few characters
+does not need to be disclosed; if in doubt, disclose.
+
+## Translations
+
+AI is useful when communicating as a non-native English speaker. If you are
+using AI to edit your comments for this purpose, please take the time to ensure
+it reflects your own voice and ideas.
+
+## Provenance and licensing
+
+You are responsible for the provenance of anything you submit. AI tools can
+reproduce code or text from their training data verbatim, which may carry a
+license incompatible with this project. By contributing, you confirm the work
+is yours to submit under the project's license and does not infringe a third
+party's rights. This is the same standard that applies to code you write by hand.
+
+## Consequences
+
+Violating this policy may get your contribution rejected and, for repeated or
+egregious violations, get you blocked from the project without further warning.
+
+## Examples
+
+Examples of things that will get your PR closed:
+
+- Point an agent to a GitHub issue, ask it to solve the issue and open a PR,
+  without understanding the issue, the PR, or testing the solution yourself.
+- Copy responses from the AI when replying to questions from maintainers,
+  without understanding the question or the response.
+  In other words, you should not "play telephone" between your AI-generated code,
+  the reviewer, and the AI tool.
+
+## Inspiration
+
+This AI policy was inspired by:
+
+- [release-plz](https://github.com/release-plz/.github/blob/main/AI_POLICY.md)
+- [astral](https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md)

--- a/files/AI_POLICY.md
+++ b/files/AI_POLICY.md
@@ -40,7 +40,7 @@ party's rights. This is the same standard that applies to code you write by hand
 
 ## Consequences
 
-Violating this policy may get your contribution rejected and, for repeated or
+Violating this policy is likely to get your contribution rejected and, for repeated or
 egregious violations, get you blocked from the project without further warning.
 
 ## Examples
@@ -49,9 +49,9 @@ Examples of things that will get your PR closed:
 
 - Point an agent to a GitHub issue, ask it to solve the issue and open a PR,
   without understanding the issue, the PR, or testing the solution yourself.
-- Copy responses from the AI when replying to questions from maintainers,
+- Copy responses from the AI (or having it post directly because it has your credentials) when replying to questions from maintainers,
   without understanding the question or the response.
-  In other words, you should not "play telephone" between your AI-generated code,
+  In other words, you should not just be a go-between for
   the reviewer, and the AI tool.
 
 ## Inspiration

--- a/files/CONTRIBUTING.md
+++ b/files/CONTRIBUTING.md
@@ -58,6 +58,11 @@ them clean. To help with keeping them clean, follow these principles:
   consistent with the existing codebase and/or it does not solve the problem it
   claims to, then we will close the PR without comment.
 
+## AI Policy
+
+If you use AI tools in any part of your contribution, you must read,
+understand, and follow our [AI Policy](./AI_POLICY.md).
+
 ## Reporting Issues
 
 - Use GitHub Issues to report bugs or request features.

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 //go:embed files/CONTRIBUTING.md
 var contributingMdContent string
 
+//go:embed files/AI_POLICY.md
+var aiPolicyMdContent string
+
 //go:embed files/CODEOWNERS
 var codeOwnersContent string
 
@@ -2382,12 +2385,13 @@ func AddHolochainBackportLabels(ctx *pulumi.Context, name string, repository *gi
 	return AddRepositoryLabels(ctx, name, repository, ShouldBackport05, ShouldBackport06)
 }
 
-// AddContributingGuide adds the shared CONTRIBUTING.md file to the repository
-// via a pull request against the `main` branch if the content has changed
+// AddContributingGuide adds the shared CONTRIBUTING.md and AI_POLICY.md files to the
+// repository via a pull request against the `main` branch if the content has changed
 // since the last deployment.
 func AddContributingGuide(ctx *pulumi.Context, name string, repository *github.Repository) error {
 	content := strings.ReplaceAll(contributingMdContent, "{{REPO_NAME}}", name)
-	contentHash := pulumi.String(fmt.Sprintf("%x", sha256.Sum256([]byte(content))))
+	aiPolicyContent := strings.ReplaceAll(aiPolicyMdContent, "{{REPO_NAME}}", name)
+	contentHash := pulumi.String(fmt.Sprintf("%x", sha256.Sum256([]byte(content+aiPolicyContent))))
 
 	baseBranch := pulumi.String("main")
 
@@ -2417,13 +2421,30 @@ func AddContributingGuide(ctx *pulumi.Context, name string, repository *github.R
 		return err
 	}
 
+	// Committed to the same branch as CONTRIBUTING.md; DependsOn serialises the
+	// two commits so they don't race on the branch head. Retained on delete for
+	// the same reason as the branch and CONTRIBUTING.md above.
+	aiPolicyFile, err := github.NewRepositoryFile(ctx, fmt.Sprintf("%s-ai-policy-md", name), &github.RepositoryFileArgs{
+		Repository:        repository.Name,
+		Branch:            branch.Branch,
+		File:              pulumi.String("AI_POLICY.md"),
+		Content:           pulumi.String(aiPolicyContent),
+		CommitMessage:     pulumi.String("chore: update the AI_POLICY.md with shared content"),
+		CommitAuthor:      pulumi.String("Holochain Repository Automation"),
+		CommitEmail:       pulumi.String("hra@holochain.org"),
+		OverwriteOnCreate: pulumi.Bool(true),
+	}, pulumi.DependsOn([]pulumi.Resource{file}), pulumi.ReplacementTrigger(contentHash), pulumi.RetainOnDelete(true))
+	if err != nil {
+		return err
+	}
+
 	_, err = github.NewRepositoryPullRequest(ctx, fmt.Sprintf("%s-contributing-md-pr", name), &github.RepositoryPullRequestArgs{
 		BaseRepository: repository.Name,
 		BaseRef:        baseBranch,
 		HeadRef:        branch.Branch,
-		Title:          pulumi.String("chore: update the CONTRIBUTING.md with shared content"),
-		Body:           pulumi.String("This PR updates the CONTRIBUTING.md file with the content from the shared file in the hc-github-config repo."),
-	}, pulumi.DependsOn([]pulumi.Resource{file}), pulumi.ReplacementTrigger(contentHash), pulumi.DeleteBeforeReplace(true))
+		Title:          pulumi.String("chore: update the CONTRIBUTING.md and AI_POLICY.md with shared content"),
+		Body:           pulumi.String("This PR updates the CONTRIBUTING.md and AI_POLICY.md files with the content from the shared files in the hc-github-config repo."),
+	}, pulumi.DependsOn([]pulumi.Resource{file, aiPolicyFile}), pulumi.ReplacementTrigger(contentHash), pulumi.DeleteBeforeReplace(true))
 	return err
 }
 


### PR DESCRIPTION
This PR adds the creation of the AI_POLICY file to the AddContributingGuide.

In adhering to the guide itself, I disclose that I did the work by asking claude to do it so I could learn more about how Pulumi works.

Possible open question:  `AddContributingGuide` does not apply to all our repos, apparently the determining decision factor of which one it should apply to is if the repo has release support.   However `holochain-client-js` does and this function isn't applied to that repo.  So there is an open question of whether we should.

As to the policy itself, I modifed what was in the proposed sample, and looked at others too to inform the actual text.