### PR TITLE
feat: add wind-tunnel-peerkit-bootstrap-relay repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -1713,6 +1713,35 @@ func main() {
 			return err
 		}
 
+		//
+		// wind-tunnel-peerkit-bootstrap-relay
+		//
+		windTunnelPeerkitBootstrapRelayDescription := "Deployable Peerkit bootstrap/relay node for Wind Tunnel testing (fork of holochain/peerkit-bootstrap-relay)."
+		windTunnelPeerkitBootstrapRelayRepositoryArgs := StandardRepositoryArgs("wind-tunnel-peerkit-bootstrap-relay", &windTunnelPeerkitBootstrapRelayDescription)
+		windTunnelPeerkitBootstrapRelayRepositoryArgs.Visibility = pulumi.String("private")
+		windTunnelPeerkitBootstrapRelay, err := github.NewRepository(ctx, "wind-tunnel-peerkit-bootstrap-relay", &windTunnelPeerkitBootstrapRelayRepositoryArgs)
+		if err != nil {
+			return err
+		}
+		if err = RequireMainAsDefaultBranch(ctx, "wind-tunnel-peerkit-bootstrap-relay", windTunnelPeerkitBootstrapRelay); err != nil {
+			return err
+		}
+		if err = StandardRepositoryAccess(ctx, "wind-tunnel-peerkit-bootstrap-relay", windTunnelPeerkitBootstrapRelay); err != nil {
+			return err
+		}
+		windTunnelPeerkitBootstrapRelayDefaultRepositoryRulesetArgs := DefaultRepositoryRulesetArgs(windTunnelPeerkitBootstrapRelay, NewRulesetOptions())
+		if _, err = github.NewRepositoryRuleset(ctx, "wind-tunnel-peerkit-bootstrap-relay-default", &windTunnelPeerkitBootstrapRelayDefaultRepositoryRulesetArgs); err != nil {
+			return err
+		}
+		if err = AddCodeOwners(ctx, "wind-tunnel-peerkit-bootstrap-relay", windTunnelPeerkitBootstrapRelay); err != nil {
+			return err
+		}
+		if err = AddDependabotYml(ctx, "wind-tunnel-peerkit-bootstrap-relay", windTunnelPeerkitBootstrapRelay, DependabotConfig{
+			EnableNpm: true,
+		}); err != nil {
+			return err
+		}
+
 		return nil
 	})
 }


### PR DESCRIPTION
## What changed

Adds a new repository, wind-tunnel-peerkit-bootstrap-relay, to the GitHub configuration for the Holochain organization. It gets standard team access, branch protection, and a CODEOWNERS file, plus automatic dependency updates since the upstream project uses npm. The repository is set to private.

## Why

This repository will hold a fork of holochain/peerkit-bootstrap-relay, adapted for Wind Tunnel testing. It has not been forked yet, this PR only prepares its configuration so it can be pushed to once created.

## Notes

No code is pushed to the new repository yet, that happens after this configuration is applied.